### PR TITLE
Remove h2 subtitle from tech-news page

### DIFF
--- a/app/views/pages/tech_news.html.erb
+++ b/app/views/pages/tech_news.html.erb
@@ -1,6 +1,5 @@
 <div class="container">
   <h1 class="tech-news-headline">#vibecoding #PromptEngineering #AI on X</h1>
-  <h2 class="tech-news-subtitle">Live feed of x posts about above hashtags, refresh page to read a different x post</h2>
 
   <% if @error_message %>
     <div class="alert alert-warning" role="alert">


### PR DESCRIPTION
Removed the subtitle 'Live feed of x posts about above hashtags, refresh page to read a different x post' to simplify the page header