### PR TITLE
Update blogs page header navigation to match portfolios style

### DIFF
--- a/app/views/shared/_blog_nav.html.erb
+++ b/app/views/shared/_blog_nav.html.erb
@@ -1,19 +1,28 @@
-<nav class="navbar navbar-expand-md navbar-light bg-light blog-nav">
-	<button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-	<span class="navbar-toggler-icon"></span>
-	</button>
-
-	<div class="container">
-		<%= link_to "Linards Berzins", root_path, class: 'navbar-brand' %>
-
-		<div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav mr-auto">
-        <%= nav_helper 'nav-link', 'li' %>  
-        <%= login_helper 'nav-link' %>  
-      </ul>
-    </div>
+<header>
+	<div class="collapse show" id="navbarHeader" style="background-color: #FFFFFF; border-bottom: 1px solid #dee2e6;">
+	  <div class="container">
+	    <div class="row">
+	      <div class="col-sm-11 py-4">
+	        <p class="text-justify" style="color: #343a40;">This is a portfolio site of mine where I showcase few Email designs, feel free to explore. Let me know if you like these.</p>
+	      </div>
+	      <div class="col-sm-1 py-4 text-right">
+	        <ul class="list-unstyled">
+	          <%= nav_helper 'text-dark', 'li' %>
+					<li><%= login_helper 'text-dark' %></li>
+	        </ul>
+	      </div>
+	    </div>
+	  </div>
 	</div>
-</nav>
+	<div class="navbar" style="background-color: #FFFFFF;">
+	  <div class="container d-flex justify-content-between">
+	    <a href="/" class="navbar-brand" style="color: #868e96;">Linards Berzins</a>
+	    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarHeader" aria-controls="navbarHeader" aria-expanded="true" aria-label="Toggle navigation" style="border-color: #868e96;">
+	      <span class="navbar-toggler-icon" style="background-image: url(&quot;data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='%23868e96' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e&quot;);"></span>
+	    </button>
+	  </div>
+	</div>
+</header>
 
 
 


### PR DESCRIPTION
Replace standard Bootstrap navbar with collapsible header design that matches the portfolios page. The new header includes a collapsible section with site description and vertical navigation links, along with a minimal navbar footer with the brand name and toggle button.