### PR TITLE
Match blog header layout to portfolio style

### DIFF
--- a/app/views/shared/_blog_nav.html.erb
+++ b/app/views/shared/_blog_nav.html.erb
@@ -1,6 +1,5 @@
-<!-- Blog navigation header matching portfolio style -->
 <header>
-	<div class="collapse show" id="navbarHeader" style="background-color: #FFFFFF; border-bottom: 1px solid #dee2e6;">
+	<div class="collapse" id="navbarHeader" style="background-color: #FFFFFF; border-bottom: 1px solid #dee2e6;">
 	  <div class="container">
 	    <div class="row">
 	      <div class="col-sm-11 py-4">
@@ -18,7 +17,7 @@
 	<div class="navbar" style="background-color: #FFFFFF;">
 	  <div class="container d-flex justify-content-between">
 	    <a href="/" class="navbar-brand" style="color: #868e96;">Linards Berzins</a>
-	    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarHeader" aria-controls="navbarHeader" aria-expanded="true" aria-label="Toggle navigation" style="border-color: #868e96;">
+	    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarHeader" aria-controls="navbarHeader" aria-expanded="false" aria-label="Toggle navigation" style="border-color: #868e96;">
 	      <span class="navbar-toggler-icon" style="background-image: url(&quot;data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='%23868e96' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e&quot;);"></span>
 	    </button>
 	  </div>


### PR DESCRIPTION
- Remove 'show' class to collapse navigation by default
- Update aria-expanded to 'false' for proper toggle state
- Maintain custom blog copy and #868e96 color
- Navigation structure now matches portfolio page exactly