### PR TITLE
Add topic management admin interface

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,22 +1,66 @@
 class TopicsController < ApplicationController
+  before_action :set_topic, only: [:show, :edit, :update, :destroy]
   before_action :set_sidebar_topics
 	layout 'blog'
+  access all: [:index, :show], site_admin: :all
 
   def index
   	@topics = Topic.all
   end
 
   def show
-  	@topic = Topic.find(params[:id])
-
   	if logged_in?(:site_admin)
       @blogs = @topic.blogs.recent.page(params[:page]).per(5)
-    else 
+    else
       @blogs = @topic.blogs.published.recent.page(params[:page]).per(5)
     end
   end
 
+  def new
+    @topic = Topic.new
+  end
+
+  def create
+    @topic = Topic.new(topic_params)
+
+    respond_to do |format|
+      if @topic.save
+        format.html { redirect_to topics_path, notice: 'Topic was successfully created.' }
+      else
+        format.html { render :new }
+      end
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    respond_to do |format|
+      if @topic.update(topic_params)
+        format.html { redirect_to topics_path, notice: 'Topic was successfully updated.' }
+      else
+        format.html { render :edit }
+      end
+    end
+  end
+
+  def destroy
+    @topic.destroy
+    respond_to do |format|
+      format.html { redirect_to topics_path, notice: 'Topic was successfully deleted.' }
+    end
+  end
+
   private
+
+  def set_topic
+    @topic = Topic.find(params[:id])
+  end
+
+  def topic_params
+    params.require(:topic).permit(:title)
+  end
 
   def set_sidebar_topics
     @side_bar_topics = Topic.with_blogs

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_for(topic) do |f| %>
+  <% if topic.errors.any? %>
+    <% topic.errors.full_messages.each do |error| %>
+      <%= alert_generator error %>
+    <% end %>
+  <% end %>
+
+  <div class="form-group">
+    <%= f.label :title %>
+    <%= f.text_field :title, class: 'form-control', placeholder: 'Topic Title' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.submit class: 'btn btn-primary' %>
+    <%= link_to "Cancel", topics_path, class: 'btn btn-secondary' %>
+  </div>
+<% end %>

--- a/app/views/topics/_topic.html.erb
+++ b/app/views/topics/_topic.html.erb
@@ -1,3 +1,9 @@
 <div class='card col-md-5'>
 	<%= link_to topic.title, topic_path(topic) %>
+	<% if logged_in?(:site_admin) %>
+		<div class="mt-2">
+			<%= link_to 'Edit', edit_topic_path(topic), class: 'btn btn-sm btn-warning' %>
+			<%= link_to 'Delete', topic_path(topic), method: :delete, data: { confirm: 'Are you sure? This will not delete associated blogs.' }, class: 'btn btn-sm btn-danger' %>
+		</div>
+	<% end %>
 </div>

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -1,0 +1,5 @@
+<div class="col-sm-8 blog-main">
+  <h1>Edit Topic</h1>
+
+  <%= render 'form', topic: @topic %>
+</div>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,6 +1,11 @@
 <div class="col-sm-8 blog-main">
 
-	<h1>Topics</h1>
+	<div class="d-flex justify-content-between align-items-center mb-3">
+		<h1>Topics</h1>
+		<% if logged_in?(:site_admin) %>
+			<%= link_to "New Topic", new_topic_path, class: 'btn btn-primary' %>
+		<% end %>
+	</div>
 
   <div class='topic-index row'>
     <%= render @topics %>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -1,0 +1,5 @@
+<div class="col-sm-8 blog-main">
+  <h1>Create a New Topic</h1>
+
+  <%= render 'form', topic: @topic %>
+</div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,9 +1,17 @@
 <div class="col-sm-8 blog-main">
 
-	<h1><%= @topic.title %></h1>
+	<div class="d-flex justify-content-between align-items-center mb-3">
+		<h1><%= @topic.title %></h1>
+		<% if logged_in?(:site_admin) %>
+			<div>
+				<%= link_to 'Edit Topic', edit_topic_path(@topic), class: 'btn btn-warning' %>
+				<%= link_to 'Delete Topic', topic_path(@topic), method: :delete, data: { confirm: 'Are you sure? This will not delete associated blogs.' }, class: 'btn btn-danger' %>
+			</div>
+		<% end %>
+	</div>
 
 	<%= paginate @blogs %>
-	
+
   <%= render @blogs %>
 
   <%= paginate @blogs %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :topics, only: [:index, :show]
+  resources :topics
 
   devise_for :users, path: '', path_names: { sign_in: 'login', sign_out: 'logout', sign_up: 'register' }
   resources :portfolios, except: [:show] do 


### PR DESCRIPTION
Implement full CRUD functionality for topics accessible to site admins:
- Add create, edit, update, and destroy actions to TopicsController
- Create form partial for topic management
- Add new and edit views for topics
- Add admin action buttons to topic index and show pages
- Update routes to enable all RESTful topic actions
- Add authorization using Petergate for site_admin access