### PR TITLE
Fix Redis connection error on Render

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,7 +6,7 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV["REDISCLOUD_URL"] %>
+  url: <%= ENV.fetch("REDIS_URL") { ENV["REDISCLOUD_URL"] } %>
   channel_prefix: WebPortfolio_production
 
 #redis://localhost:6379/1

--- a/render.yaml
+++ b/render.yaml
@@ -22,6 +22,17 @@ services:
         value: enabled
       - key: RAILS_SERVE_STATIC_FILES
         value: enabled
+      - key: REDIS_URL
+        fromService:
+          type: redis
+          name: webportfolio-redis
+          property: connectionString
+
+  - type: redis
+    name: webportfolio-redis
+    plan: free
+    maxmemoryPolicy: allkeys-lru
+    ipAllowList: []
 
 # Using external database (Supabase/Neon) - no expiration!
 # Add DATABASE_URL manually in Render dashboard


### PR DESCRIPTION
- Add Redis service to render.yaml configuration
- Update cable.yml to use REDIS_URL (Render default) with fallback to REDISCLOUD_URL
- Configure free Redis instance with allkeys-lru eviction policy
- Link Redis URL from service to web app environment variables

This fixes the "Error connecting to Redis on 127.0.0.1:6379" error