### PR TITLE
Fix breadcrumb navigation structure and separators

### DIFF
--- a/app/assets/stylesheets/blogs.scss
+++ b/app/assets/stylesheets/blogs.scss
@@ -116,9 +116,9 @@ h6 .h6{
     font-size: 3.5rem;
   }
 
-  .breadcrumb.row {
-  margin-left: auto;
-  padding-left: auto;
+  .breadcrumb {
+    margin-left: auto;
+    padding-left: auto;
   }
 }
 
@@ -272,15 +272,15 @@ h6 .h6{
 
 
 
-.breadcrumb.row {
+.breadcrumb {
   background-color: #FFFFFF;
   border-bottom: 1px solid #ffffff;
- border-radius: 0px;
-  padding-left:1rem;
+  border-radius: 0px;
+  padding-left: 1rem;
   margin: 0 0 20px 0;
--webkit-box-shadow: 0px -2px 6px -4px rgba(0,0,0,0.75);
--moz-box-shadow: 0px -2px 6px -4px rgba(0,0,0,0.75);
-box-shadow: 0px -2px 6px -4px rgba(0,0,0,0.75);
+  -webkit-box-shadow: 0px -2px 6px -4px rgba(0,0,0,0.75);
+  -moz-box-shadow: 0px -2px 6px -4px rgba(0,0,0,0.75);
+  box-shadow: 0px -2px 6px -4px rgba(0,0,0,0.75);
 }
 
 .blogcrumb a{

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -1,19 +1,21 @@
 
 <div class="col-sm-8 blog-main">
 	<h2> <%= @blog.title %></h2>
-    <nav class="breadcrumb row">
-        <div class='col'>
-        <%= link_to "Home", root_path, class: 'breadcrumb-item' %>
-        <%= link_to @blog.topic.title, topic_path(@blog.topic), class: 'breadcrumb-item' %>
-     
-        <span class="breadcrumb-item active"><%= @blog.title %></span>
-     
+    <div class="row">
+      <div class="col">
+        <nav aria-label="breadcrumb">
+          <ol class="breadcrumb">
+            <li class="breadcrumb-item"><%= link_to "Home", root_path %></li>
+            <li class="breadcrumb-item"><%= link_to @blog.topic.title, topic_path(@blog.topic) %></li>
+            <li class="breadcrumb-item active" aria-current="page"><%= @blog.title %></li>
+          </ol>
+        </nav>
         <span class="float-right blogcrumb">
           <%= link_to fa_icon('pencil-square-o'), edit_blog_path(@blog) if logged_in?(:site_admin) %>
           <%= link_to fa_icon('trash'), @blog, method: :delete, data: { confirm: 'Are you sure you want to delete this post' } if logged_in?(:site_admin) %>
         </span>
-        </div>
-      </nav>
+      </div>
+    </div>
   <hr>
 	<p><%= @blog.topic.title %></p>
   <hr>


### PR DESCRIPTION
Restructured breadcrumb HTML to use proper Bootstrap markup with ol/li elements instead of direct anchor children. Updated CSS selectors from .breadcrumb.row to .breadcrumb to match new structure. This fixes the issue where forward slashes appeared as separate clickable elements.