### PR TITLE
Make blog footer stick to bottom and update link text

### DIFF
--- a/app/views/layouts/blog.html.erb
+++ b/app/views/layouts/blog.html.erb
@@ -13,24 +13,24 @@
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
-  <body>
+  <body style="display: flex; flex-direction: column; min-height: 100vh;">
+    <div style="flex: 1; display: flex; flex-direction: column;">
+      <%= render 'shared/blog_nav' %>
+      <%= render 'shared/blog_masthead' %>
 
-    <%= render 'shared/blog_nav' %>
-    <%= render 'shared/blog_masthead' %>
+      <div class="container" style="flex: 1;">
+        <div class="row">
 
-    <div class="container">
-      <div class="row">
+          <%= yield %>
 
-        <%= yield %>
-
-        <%= render 'shared/blog_sidebar' %>
+          <%= render 'shared/blog_sidebar' %>
 
         </div>
-        
-         <%= render 'shared/blog_footer' %>
-
-         <%= alerts %>
       </div>
-    
+    </div>
+
+    <%= render 'shared/blog_footer' %>
+    <%= alerts %>
+
   </body>
 </html>

--- a/app/views/shared/_blog_footer.html.erb
+++ b/app/views/shared/_blog_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="text-muted">
 	<div class="container">
 	  <p class="float-right">
-	  <%= link_to "View all portfolios", portfolios_path %> /
+	  <%= link_to "View all blogs", blogs_path %> /
 	    <a href="#">Back to top</a>
 	  </p>
 	  <%= @copyright %>


### PR DESCRIPTION
- Add flexbox layout to blog page to push footer to bottom
- Change "View all portfolios" link to "View all blogs"
- Restructure blog layout to match portfolio sticky footer approach