### PR TITLE
Remove bio section from blog sidebar

### DIFF
--- a/app/views/shared/_blog_sidebar.html.erb
+++ b/app/views/shared/_blog_sidebar.html.erb
@@ -1,10 +1,5 @@
 
 <div class="col-sm-3 offset-sm-1 blog-sidebar">
-  <div class="sidebar-module sidebar-module-inset">
-    <h5>the shortest bio</h5>
-    <p>Email developer currently at <a href="https://www.merkleinc.com/europe">Merkle</a>. Looking for freelance work. Contact me via social or <a href="mailto:linardsbrzins@gmail.com">email</a></p>
-  </div>
-
   <div class="sidebar-module social_text">
     <h4>Social</h4>
     <ol class="list-unstyled social_links">


### PR DESCRIPTION
- Removed 'the shortest bio' sidebar module
- Cleaned up blog sidebar to only show social links and topics