### PR TITLE
Remove 'Social' h4 heading from blog sidebar

### DIFF
--- a/app/views/shared/_blog_sidebar.html.erb
+++ b/app/views/shared/_blog_sidebar.html.erb
@@ -1,7 +1,6 @@
 
 <div class="col-sm-3 offset-sm-1 blog-sidebar">
   <div class="sidebar-module social_text">
-    <h4>Social</h4>
     <ol class="list-unstyled social_links">
       <li><a href="https://www.linkedin.com/in/linardsberzins/"><%= fa_icon "linkedin" %></a></li>
       <li><a href="https://github.com/linardsb"><%= fa_icon "github" %></a></li>


### PR DESCRIPTION
Removed the h4 tag containing 'Social' text from the social links section in the blog sidebar for a cleaner UI.