### PR TITLE
Set sidebar h4 color to #888

### DIFF
--- a/app/assets/stylesheets/blogs.scss
+++ b/app/assets/stylesheets/blogs.scss
@@ -260,6 +260,9 @@ h6 .h6{
       padding-right:0px;
     }
   }
+  h4 {
+    color: #888;
+  }
 }
 
 .card {


### PR DESCRIPTION
Updated the .social_text styling to set h4 elements to color #888, affecting the 'Blog topics' heading in the blog sidebar.