### PR TITLE
Set portfolio text color to #868e96

### DIFF
--- a/app/assets/stylesheets/portfolios.scss
+++ b/app/assets/stylesheets/portfolios.scss
@@ -133,3 +133,18 @@ footer p {
 h1.jumbotron-heading {
   color:#868e96 !important;
 }
+
+/* Portfolio show page text color */
+.portfolio_container .col-md-5 {
+  h1, h2, h3, h4, h5, h6, p, em, span {
+    color: #868e96 !important;
+  }
+}
+
+/* Portfolio item card text color */
+.portfolio-box .card-text {
+  color: #868e96 !important;
+  span, a {
+    color: #868e96 !important;
+  }
+}


### PR DESCRIPTION
Applied color #868e96 to all text in portfolio show pages and portfolio item cards for consistent styling.