### PR TITLE
Remove 'Blog' from topics heading

### DIFF
--- a/app/views/shared/_blog_sidebar.html.erb
+++ b/app/views/shared/_blog_sidebar.html.erb
@@ -10,7 +10,7 @@
  
   <% if @side_bar_topics %>
       <div class="sidebar-module social_text">
-        <h4>Blog topics</h4>
+        <h4>topics</h4>
         <% @side_bar_topics.each do |topic| %>
           <p><%= link_to topic.title, topic_path(topic) %></p>
         <% end %>


### PR DESCRIPTION
Update sidebar h4 text from 'Blog topics' to just 'topics' for cleaner presentation.