### PR TITLE
Make footer content stack vertically on mobile

### DIFF
--- a/app/views/shared/_blog_footer.html.erb
+++ b/app/views/shared/_blog_footer.html.erb
@@ -9,6 +9,18 @@
 	      color: #993550 !important;
 	      text-decoration: none;
 	    }
+
+	    @media (max-width: 575px) {
+	      footer .float-right {
+	        float: none !important;
+	        text-align: center;
+	        margin-bottom: 0.5rem;
+	      }
+
+	      footer .container {
+	        text-align: center;
+	      }
+	    }
 	  </style>
 	  <%= @copyright %>
 	</div>


### PR DESCRIPTION
Add media query for viewport width 575px and lower to:
- Remove float-right behavior on mobile
- Center-align footer content
- Stack links and copyright vertically with proper spacing