### PR TITLE
Make footer content stack vertically on mobile devices

### DIFF
--- a/app/assets/stylesheets/portfolios.scss
+++ b/app/assets/stylesheets/portfolios.scss
@@ -148,3 +148,16 @@ h1.jumbotron-heading {
     color: #6c757d !important;
   }
 }
+
+/* Mobile footer styles */
+@media (max-width: 575px) {
+  footer p.float-right {
+    float: none !important;
+    text-align: center;
+    margin-bottom: 0.5rem;
+  }
+
+  footer .container {
+    text-align: center;
+  }
+}


### PR DESCRIPTION
Add media query for viewport width 575px and below to stack footer content vertically with centered text alignment for better mobile UX.