### PR TITLE
Update home page copy to describe Rails app and content

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,6 @@
 <div class="inner cover">
   <h1 class="cover-heading">HTML Email and other design portfolios</h1>
-    <p class="lead">Purpose of this website is to show some of my work in HTML Emails, web interfaces and widgets.</p>
+    <p class="lead">This Rails app shows some of my work in HTML Emails, other projects and blog entries</p>
     <p class="lead">
       <%= link_to "About", about_me_path, class: "btn btn-lg btn-secondary" %>
     </p>


### PR DESCRIPTION
Change description from "web interfaces and widgets" to "other projects and blog entries" to better reflect the actual content of the site.