### PR TITLE
Add bottom margin to navigation list items

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,7 +49,7 @@ module ApplicationHelper
     nav_links = ''
 
     nav_items.each do |item|
-      nav_links << "<#{tag_type}><a href='#{item[:url]}' class='#{style} #{active? item[:url]}'>#{item[:title]}</a></#{tag_type}>"
+      nav_links << "<#{tag_type} style='margin-bottom: 1rem;'><a href='#{item[:url]}' class='#{style} #{active? item[:url]}'>#{item[:title]}</a></#{tag_type}>"
     end
 
     nav_links.html_safe

--- a/app/views/shared/_portfolio_nav.html.erb
+++ b/app/views/shared/_portfolio_nav.html.erb
@@ -8,7 +8,7 @@
 	      <div class="col-sm-1 py-4 text-right">
 	        <ul class="list-unstyled">
 	          <%= nav_helper 'text-dark', 'li' %>
-					<li><%= login_helper 'text-dark' %></li>
+					<li style="margin-bottom: 1rem;"><%= login_helper 'text-dark' %></li>
 	        </ul>
 	      </div>
 	    </div>


### PR DESCRIPTION
Added margin-bottom: 1rem to each list item in the portfolio navigation for better spacing:
- Updated nav_helper to include inline style on generated li tags
- Added inline style to the login helper li tag