### PR TITLE
Remove comment posting functionality from blog posts

### DIFF
--- a/app/assets/javascripts/channels/blogs.coffee
+++ b/app/assets/javascripts/channels/blogs.coffee
@@ -5,18 +5,7 @@ jQuery(document).on 'turbolinks:load', ->
 			channel: "BlogsChannel"
 			blog_id: comments.data('blog-id')
 		},
-		connected: -> 
+		connected: ->
 		disconnected: ->
 		received: (data) ->
 			comments.append data['comment']
-		send_comment: (comment, blog_id) ->
-			@perform 'send_comment', comment: comment, blog_id: blog_id
-	$('#new_comment').submit (e) ->
-		$this = $(this)
-		textarea = $this.find('#comment_content')
-		if $.trim(textarea.val()).length > 1
-			App.global_chat.send_comment textarea.val(),
-			comments.data('blog-id')
-			textarea.val('')
-		e.preventDefault()
-		return false

--- a/app/channels/blogs_channel.rb
+++ b/app/channels/blogs_channel.rb
@@ -5,8 +5,4 @@ class BlogsChannel < ApplicationCable::Channel
 
   def unsubscribed
   end
-
-  def send_comment(data)
-    current_user.comments.create!(content: data['comment'], blog_id: data['blog_id'])
-  end
 end

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -20,7 +20,6 @@ class BlogsController < ApplicationController
   def show
     if logged_in?(:site_admin) || @blog.published?
       @blog = Blog.includes(:comments).friendly.find(params[:id])
-      @comment = Comment.new
 
       @page_title = @blog.title
       @seo_keywords = @blog.body

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -22,7 +22,6 @@
 	<%= link_to 'Edit', edit_blog_path(@blog) if logged_in?(:site_admin) %>
 	<%= markdown @blog.body %>
   <p class="blog_body_copy"></p>
-	<%= render 'comments/comment_form' %>
 	<div id="comments" data-blog-id="<%= @blog.id %>">
 		<%= render @blog.comments %>
 	</div>


### PR DESCRIPTION
This change disables the ability to post new comments on blog posts while preserving the display of existing comments. The following changes were made:

- Removed comment form from blog show page
- Removed @comment initialization from blogs controller
- Removed send_comment method from BlogsChannel
- Removed form submission handler from JavaScript

Users can still view existing comments but cannot submit new ones.