### PR TITLE
Add image support to blog posts markdown formatting

### DIFF
--- a/app/views/blogs/_form.html.erb
+++ b/app/views/blogs/_form.html.erb
@@ -30,6 +30,7 @@
     <small class="form-text text-muted">
       <strong>Markdown formatting:</strong>
       <code>[Link Text](https://url.com)</code> for links •
+      <code>![Alt Text](image-url)</code> for images •
       <code>**bold**</code> •
       <code>*italic*</code> •
       <code>```code```</code> for code blocks


### PR DESCRIPTION
Updated the blog post form to include image syntax in the markdown formatting help text. Users can now add images to their blog posts using the standard markdown syntax: ![Alt Text](image-url)