### PR TITLE
Style blog post images with max-width and center alignment

### DIFF
--- a/app/assets/stylesheets/blogs.scss
+++ b/app/assets/stylesheets/blogs.scss
@@ -111,6 +111,14 @@ h6 .h6{
   text-decoration: none;
 }
 
+.blog-main img {
+  max-width: 400px;
+  height: auto;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 @media (min-width: 40em) {
   .breadcrumb {
     margin-left: auto;


### PR DESCRIPTION
Add CSS rules to center images in blog posts with a maximum width of 400px and auto height to maintain aspect ratio. Images are centered using block display with auto margins.