### PR TITLE
Fix Blog model validation and add explicit published/draft scopes

### DIFF
--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -3,9 +3,12 @@ class Blog < ApplicationRecord
 	extend FriendlyId
 	friendly_id :title, use: :slugged
 
-	validates_presence_of :title, :body, :topic_id
+	validates_presence_of :title, :body
 
 	belongs_to :topic, optional: true
+
+	scope :published, -> { where(status: 1) }
+	scope :draft, -> { where(status: 0) }
 
 	has_many :comments, dependent: :destroy
 


### PR DESCRIPTION
- Removed topic_id from presence validation since topic association is optional
- Added explicit published and draft scopes to ensure proper filtering
- This resolves the contradiction between required validation and optional association