### PR TITLE
Fix markdown code block rendering error

### DIFF
--- a/app/helpers/blogs_helper.rb
+++ b/app/helpers/blogs_helper.rb
@@ -5,6 +5,7 @@ module BlogsHelper
 
   class CodeRayify < Redcarpet::Render::HTML
     def block_code(code, language)
+      language = language.present? ? language.to_sym : :text
       CodeRay.scan(code, language).div
     end
 


### PR DESCRIPTION
Handle nil language parameter in CodeRayify#block_code to prevent "Symbol or String expected, but NilClass given" error when rendering markdown code blocks without a specified language. Default to :text for plain text rendering.