### PR TITLE
Fix markdown code block rendering issues

### DIFF
--- a/app/helpers/blogs_helper.rb
+++ b/app/helpers/blogs_helper.rb
@@ -16,7 +16,7 @@ module BlogsHelper
   end
 
   def markdown(text)
-    coderayified = CodeRayify.new(filter_html: true, hard_wrap: true)
+    coderayified = CodeRayify.new(filter_html: true)
 
     options = {
       fenced_code_blocks: true,

--- a/app/views/blogs/_blog.html.erb
+++ b/app/views/blogs/_blog.html.erb
@@ -2,6 +2,6 @@
     <h2 class="blog-post-title"><%= link_to blog.title.upcase, blog %></h2>
     <p class="blog-post-meta">Published <%= distance_of_time_in_words(blog.created_at, Time.now) %> ago by Linards</p>
     <%= render partial: 'blogs/admin_actions', locals: { blog: blog } %>
-    <p><%= markdown blog.body %></p>
+    <%= markdown blog.body %>
  </div>
  


### PR DESCRIPTION
- Remove hard_wrap option that was interfering with fenced code blocks
- Remove invalid <p> tag wrapper around markdown output in blog partial